### PR TITLE
Add parameter to control which branch to cut the release from

### DIFF
--- a/.github/workflows/regular-release.yaml
+++ b/.github/workflows/regular-release.yaml
@@ -18,6 +18,10 @@ on:
           - preminor
           - prepatch
           - prerelease
+      baseBranch:
+        description: "The core repository branch to cut this Pulsar release from. Leave blank to use the core repository's default branch."
+        required: false
+        type: string
 
 env:
   # Variables needed
@@ -60,6 +64,11 @@ jobs:
         path: pulsar
         token: ${{ secrets.AUTH_TOKEN_GITHUB }}
 
+    - name: Switch to the Specified Base Branch
+      if: ${{ inputs.baseBranch }}
+      run: git switch ${{ inputs.baseBranch }}
+      working-directory: pulsar
+
     - name: Find new Version
       run: |
         node ./findNextPulsarVersion \
@@ -68,7 +77,7 @@ jobs:
           --bumpType ${{ inputs.releaseType }}
 
     - name: Create new branch under new version
-      run: git switch -c v${{ env.nextPulsarVersion }}-release origin/master
+      run: git switch -c v${{ env.nextPulsarVersion }}-release
       working-directory: pulsar
 
     - name: Bump Pulsar Version
@@ -93,9 +102,15 @@ jobs:
 
     - name: Create GitHub Pull Request
       run: |
+        BASE_OPTION=""
+        if [ -n "${{ inputs.baseBranch }}" ]; then
+          BASE_OPTION="--base ${{ inputs.baseBranch }}
+        fi
+
         GhPrCreateOutput="$(gh pr create \
           --title "v${{ env.nextPulsarVersion }} Release" \
-          --body "Automated Regular Release")"
+          --body "Automated Regular Release" \
+          ${BASE_OPTION})"
         echo "releasePrLink=$(echo $GhPrCreateOutput)" >> $GITHUB_ENV
       working-directory: pulsar
 

--- a/.github/workflows/release-followups.yml
+++ b/.github/workflows/release-followups.yml
@@ -5,6 +5,11 @@ name: Followup Steps to Regular Release
 
 on:
   workflow_dispatch:
+    inputs:
+      baseBranch:
+        description: "The core repository branch this Pulsar release lives on. Leave blank to use the core repository's default branch. Only relevant if a version bump in package.json lives on a non-default (e.g. \"releases\" branch)."
+        required: false
+        type: string
 
 env:
   # Variables needed
@@ -43,6 +48,11 @@ jobs:
       with:
         repository: pulsar-edit/pulsar
         path: pulsar
+
+    - name: Switch to the Specified Branch
+      if: ${{ inputs.baseBranch }}
+      run: git switch ${{ inputs.baseBranch }}
+      working-directory: pulsar
 
     - name: Find current Version
       run: |


### PR DESCRIPTION
### Description of change

Adds a parameter to control which branch to cut the release from.

Leave the new, optional `baseBranch` parameter blank to use the core repository's default branch.
    
(Setting the parameter will open the version bump PR pointing to the specified branch as well, if any, otherwise by default the version bump PR also points to the core repo's default branch.)

#### Bonus side-effect (tangent)

By the way, as a side effect of the work needed to be able to handle other non-default branches, this PR also stops hard-coding `master` as a branch name anywhere in the actual code. So, if merged, this repository should then be able to handle it if we should ever change the default branch name of core repo, e.g. to `main`. I don't expect we will after all this time, but yeah, this could handle it.

### Context and example usage

This change is designed to make it easy to set up non-default-branch release branches. For example, to curate which hotfix commits should be included, and which "more minor-level" or "more major-level" changes ought to be excluded from the release, regardless of whats been merged to the default branch or not.

On-the-nose specific (hypothetical?) example, for illustrative purposes: A branch could be called `1.131-releases` and include only hotfixes since `1.131.2` for an upcoming `1.131.3` release, even if more "minor" or "major" changes (such as an Electron version bump?) may have already landed on `master` branch.

Setting the `baseBranch` param here to `1.131-releases` would then allow making a patch release to exist on top of `1.131.2` without disturbing or requiring changes to the default `master` branch.

### Limitation (only the main workflow, not the followups)

As of my writing this, only the main workflow is addressed. I haven't looked through the followup workflow to see how it might be set up to handle non-default branches, but it honestly might not be that hard, so maybe I should?

### Verification process

I _could_ try this on my forks of `pulsar-release-workflow` and `pulsar`, respectively... or we could test it in prod, chasing the resulting PR's, Actions workflows and tag pushes and closing/deleting/canceling them as need be?