### PR TITLE
Miscellaneous fixes

### DIFF
--- a/addBuildIdToVersion/index.js
+++ b/addBuildIdToVersion/index.js
@@ -26,7 +26,7 @@ wrapper({
 
     packageJSON.version = originalVersion + opts.buildID,
 
-    fs.writeFileSync(opts.packageLocation, JSON.stringify(packageJSON, null, 2), { encoding: "utf8" });
+    fs.writeFileSync(opts.packageLocation, JSON.stringify(packageJSON, null, 2) + '\n', { encoding: "utf8" });
 
     console.log(`Changed Version from '${originalVersion}' to '${packageJSON.version}'`);
   }

--- a/createReleaseAndUploadBins/index.js
+++ b/createReleaseAndUploadBins/index.js
@@ -11,7 +11,7 @@
     * notes:
 
   Based almost entirely off work here:
-    https://github.com/pulsar-edit/pulsar/blob/master/script/rolling-release-scripts/rolling-release-binary-upload.js
+    https://github.com/pulsar-edit/pulsar/blob/HEAD/script/rolling-release-scripts/rolling-release-binary-upload.js
 */
 
 const fs = require("fs");

--- a/downloadBinsWhenPossible/getGitHubBins.js
+++ b/downloadBinsWhenPossible/getGitHubBins.js
@@ -57,7 +57,7 @@ async function getGitHubBins(opts) {
 
       if (workflow.name === opts.githubActionName && workflow.event === "push") {
         // We choose `push` because that matches the logic that controls when we
-        // sign a build in GitHub Actions: https://github.com/pulsar-edit/pulsar/blob/master/.github/workflows/build.yml#L133
+        // sign a build in GitHub Actions: https://github.com/pulsar-edit/pulsar/blob/HEAD/.github/workflows/build.yml#L194
         targetWorkflow = workflow;
       }
     }

--- a/removeBuildIdFromVersion/index.js
+++ b/removeBuildIdFromVersion/index.js
@@ -26,7 +26,7 @@ wrapper({
 
     packageJSON.version = originalVersion.replace(opts.buildID, "");
 
-    fs.writeFileSync(opts.packageLocation, JSON.stringify(packageJSON, null, 2), { encoding: "utf8" });
+    fs.writeFileSync(opts.packageLocation, JSON.stringify(packageJSON, null, 2) + '\n', { encoding: "utf8" });
 
     console.log(`Changed Version from '${originalVersion}' to '${packageJSON.version}'`);
   }

--- a/writeNewVersion/index.js
+++ b/writeNewVersion/index.js
@@ -21,6 +21,6 @@ wrapper({
   run: (opts) => {
     const packageJSON = JSON.parse(fs.readFileSync(opts.packageLocation, { encoding: "utf8" }));
     packageJSON.version = opts.version;
-    fs.writeFileSync(opts.packageLocation, JSON.stringify(packageJSON, null, 2), { encoding: "utf8" });
+    fs.writeFileSync(opts.packageLocation, JSON.stringify(packageJSON, null, 2) + '\n', { encoding: "utf8" });
   }
 });


### PR DESCRIPTION
### Changes

Save Pulsar's <kbd>package.json</kbd> with trailing newline

Git gets slightly grumpy at files saved with no trailing newline character at the end of them.

Also causes some whitespace churn if anyone manually edits the file in-between releases, since real humans' editors typically add such trailing newline characters automatically.

---

Update URLs in two code comments
    
Make the URLs use <kbd>/blob/HEAD</kbd> rather than <kbd>/blob/master</kbd>, so if we ever change core repo's efault branch e.g. to "main" the links will still work.

Also, update the line number for one of our core repo <kbd>workflow.yml</kbd> files -- the CI file has had some situational workarounds added near the top over the years, so the macOS code signing logic check is further down in the file now.

### Verification process

I tried the equivalent `fs.writeFileSync()` calls in a Node REPL against core repo, and did <kbd>git diff</kbd> to see if trailing newline changes were detected in my local copy of <kbd>package.json</kbd>. The version as-written in this PR is the one that preserves a trailing newline and shows no file changes in <kbd>package.json</kbd> relative to current <kbd>master</kbd>.

I visited the updated GitHub.com URLs in the code comments myself, to verify the redirect from <kbd>HEAD</kbd> ref works, and that the macOS signing logic mentioned is highlighted by the given line number.