### PR TITLE
Fix `baseBranch` input logic

### DIFF
--- a/.github/workflows/regular-release.yaml
+++ b/.github/workflows/regular-release.yaml
@@ -61,13 +61,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: pulsar-edit/pulsar
+        ref: ${{ inputs.baseBranch }}
         path: pulsar
         token: ${{ secrets.AUTH_TOKEN_GITHUB }}
-
-    - name: Switch to the Specified Base Branch
-      if: ${{ inputs.baseBranch }}
-      run: git switch ${{ inputs.baseBranch }}
-      working-directory: pulsar
 
     - name: Find new Version
       run: |

--- a/.github/workflows/regular-release.yaml
+++ b/.github/workflows/regular-release.yaml
@@ -100,7 +100,7 @@ jobs:
       run: |
         BASE_OPTION=""
         if [ -n "${{ inputs.baseBranch }}" ]; then
-          BASE_OPTION="--base ${{ inputs.baseBranch }}
+          BASE_OPTION="--base ${{ inputs.baseBranch }}"
         fi
 
         GhPrCreateOutput="$(gh pr create \

--- a/.github/workflows/release-followups.yml
+++ b/.github/workflows/release-followups.yml
@@ -47,12 +47,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: pulsar-edit/pulsar
+        ref: ${{ inputs.baseBranch }}
         path: pulsar
-
-    - name: Switch to the Specified Branch
-      if: ${{ inputs.baseBranch }}
-      run: git switch ${{ inputs.baseBranch }}
-      working-directory: pulsar
 
     - name: Find current Version
       run: |


### PR DESCRIPTION
### Context

Follow-up fixes for #6.

### Description of changes

Fix 1 (https://github.com/pulsar-edit/pulsar-release-workflow/commit/cafb6c254713b2d21ce4bfcc28e50cad7043593e):

The `actions/checkout` action does a very minimal clone by default. It doesn't fetch info about any branches other than the one you have it checkout. We could have it fetch info for more branches, but that'd be inefficient.

So... **simply have `actions/checkout` checkout the branch specified in the `baseBranch` input to the workflow!** That way we don't have to switch to it later. Highly efficient! (And not broken, since `git switch`ing to a ref we don't know about... doesn't work!)

Fix 2 (https://github.com/pulsar-edit/pulsar-release-workflow/commit/2a630da74f61987a547af84b99fb6580f6356663):

I missed a closing `"` quotation mark in a bash snippet the first go-around, somehow :|. Oh well! **Added the closing quotation mark, very straight-forward...**

### Verification process

Tested in CI already:

- https://github.com/pulsar-edit/pulsar-release-workflow/actions/runs/23324731946/job/67843445070
  - `baseBranch` specified ✅ (checks out the specified branch, can post a version bump PR successfully, can wait for bins, etc.)
- https://github.com/pulsar-edit/pulsar-release-workflow/actions/runs/23323667903/job/67840206350#step:13:20
  - `baseBranch` not specified just checks out the default Pulsar core repo branch ✅.
  - (CI failure is from running the workflow a second time after the resulting `v1.131.3-release` branch already existed at core repo, so pushing it again fails (it's not a `git push --force` and shouldn't be, IMO). But the `actions/checkout` run _does_ successfully run and checkout the default Pulsar core repo branch, no problem. The latter CI run just above validates this given failure point does not occur if running once for a given attempted version bump, i.e. the supported scenario for this repo _does_ work.)

Note: The issues fixed by this PR were discovered from these runs:
- https://github.com/pulsar-edit/pulsar-release-workflow/actions/runs/23322959455/job/67837977271
  - (`git switch` failing for a ref `git` doesn't know about, due to minimal clone of only another branch -- fixed by the first commit of this PR. https://github.com/pulsar-edit/pulsar-release-workflow/commit/cafb6c254713b2d21ce4bfcc28e50cad7043593e)
- https://github.com/pulsar-edit/pulsar-release-workflow/actions/runs/23323667903/job/67840206350
  - ("Create GitHub Pull Request" step fails due to a lack of a closing quotation mark in some Bash script I wrote :|. Fixed in the second commit of this PR: https://github.com/pulsar-edit/pulsar-release-workflow/commit/2a630da74f61987a547af84b99fb6580f6356663)