### PR TITLE
deps: bump `yauzl`; has fix for early-exit issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1068,9 +1068,9 @@
       "license": "ISC"
     },
     "node_modules/yauzl": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
-      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.1.tgz",
+      "integrity": "sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==",
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",


### PR DESCRIPTION
Contains a fix for an issue we've been having where the "download and unzip CI assets" part of the workflow ([`downloadBinsWhenPossible`](https://github.com/pulsar-edit/pulsar-release-workflow/tree/main/downloadBinsWhenPossible)) exits early... (at least this issue happens on Node 26. It seems to also happen on Node 24, but not Node 22 or Node 25.)

See:
- https://github.com/thejoshwolfe/yauzl/issues/169
- https://github.com/thejoshwolfe/yauzl/pull/170

Should fix: #9 

